### PR TITLE
"async & performance" - ch 3 - typo in "Thenable Duck Typing"

### DIFF
--- a/async & performance/ch3.md
+++ b/async & performance/ch3.md
@@ -422,7 +422,7 @@ Both `v1` and `v2` will be assumed to be thenables. You can't control or predict
 
 Sound implausible or unlikely? Perhaps.
 
-But keep in mind that there were several well-known non-Promise libraries preexisting in the community prior to ES6 that happened to already have a method on them called `then(..)`. Some of those libraries chose to rename their own methods to avoid collision (that sucks!). Others have simply been relegated to the unfortunate status of "incompatible with Promise-based coding" in reward for their inability to change to get out of the way.
+But keep in mind that there were several well-known non-Promise libraries preexisting in the community prior to ES6 that happened to already have a method on them called `then(..)`. Some of those libraries chose to rename their own methods to avoid collision (that sucks!). Others have simply been relegated to the unfortunate status of "incompatible with Promise-based coding" in reward for their inability to change.
 
 The standards decision to hijack the previously nonreserved -- and completely general-purpose sounding -- `then` property name means that no value (or any of its delegates), either past, present, or future, can have a `then(..)` function present, either on purpose or by accident, or that value will be confused for a thenable in Promises systems, which will probably create bugs that are really hard to track down.
 


### PR DESCRIPTION
It looks like there was a bit of an error deciding which phrasing to use, and both ended up in the doc. I think "inability to change" sounds better.
